### PR TITLE
Use LibraryController lookup, and seek only if not stopped

### DIFF
--- a/mopidy_autoplay/frontend.py
+++ b/mopidy_autoplay/frontend.py
@@ -211,6 +211,7 @@ class AutoplayFrontend(pykka.ThreadingActor, core.CoreListener):
             playback = self._get_config(state, 'playback', 'state')
             if playback == 'stopped':
                 self.core.playback.stop()
+                return
             elif playback == 'playing':
                 self.core.playback.play(tlid=tlid)
             elif playback == 'paused':

--- a/mopidy_autoplay/frontend.py
+++ b/mopidy_autoplay/frontend.py
@@ -141,7 +141,6 @@ class AutoplayFrontend(pykka.ThreadingActor, core.CoreListener):
         # Reset tracklist
         tlid = None
 
-        playlist_schemes = tuple(self.core.playlists.get_uri_schemes().get())
         uris = []
         for uri in self._get_config(state, 'tracklist', 'uris'):
             if uri.startswith('match:'):
@@ -156,27 +155,23 @@ class AutoplayFrontend(pykka.ThreadingActor, core.CoreListener):
                     logger.warning(
                         "Matching for URI %s not supported: %s",
                         match, uri)
-            elif uri.startswith(playlist_schemes):
-                # Add contents of known playlists to the list of URIs
-                uris.extend(
-                    [track.uri
-                     for track
-                     in self.core.playlists.get_items(uri).get() or []])
             else:
                 uris.append(uri)
 
         if uris:
-            # Clear tracklist and add URIs
+            # Generate a list of track URIs from URIs
+            track_uris = [track.uri for sublist in self.core.library.lookup(uris).get().values() for track in sublist]
+            # Clear tracklist and add tracks
             self.core.tracklist.clear()
             self.core.tracklist.set_consume(False)
-            self.core.tracklist.add(uris=uris)
+            self.core.tracklist.add(uris=track_uris)
             # Switch to specified index
             index = self._get_config(state, 'tracklist', 'index') or 0
 
             # We count the index, because we might have the same track more
             # than once in the tracklist
             tl_tracks = self.core.tracklist.get_tl_tracks().get()
-            for i, uri in enumerate(uris):
+            for i, uri in enumerate(track_uris):
                 if tl_tracks:
                     track_uri = tl_tracks[0].track.uri
                 else:

--- a/mopidy_autoplay/frontend.py
+++ b/mopidy_autoplay/frontend.py
@@ -160,7 +160,12 @@ class AutoplayFrontend(pykka.ThreadingActor, core.CoreListener):
 
         if uris:
             # Generate a list of track URIs from URIs
-            track_uris = [track.uri for sublist in self.core.library.lookup(uris).get().values() for track in sublist]
+            track_uris = [
+                track.uri
+                for sublist
+                in self.core.library.lookup(uris).get().values()
+                for track
+                in sublist]
             # Clear tracklist and add tracks
             self.core.tracklist.clear()
             self.core.tracklist.set_consume(False)

--- a/mopidy_autoplay/frontend.py
+++ b/mopidy_autoplay/frontend.py
@@ -216,14 +216,15 @@ class AutoplayFrontend(pykka.ThreadingActor, core.CoreListener):
             playback = self._get_config(state, 'playback', 'state')
             if playback == 'stopped':
                 self.core.playback.stop()
-                return
             elif playback == 'playing':
                 self.core.playback.play(tlid=tlid)
             elif playback == 'paused':
                 self.core.playback.pause()
-            time_position = self._get_config(state, 'playback', 'time_position')
-            if time_position is not None:
-                self.core.playback.seek(time_position)
+            if playback != 'stopped':
+                time_position = self._get_config(
+                    state, 'playback', 'time_position')
+                if time_position is not None:
+                    self.core.playback.seek(time_position)
 
     def store_state(self):
         """

--- a/mopidy_autoplay/frontend.py
+++ b/mopidy_autoplay/frontend.py
@@ -162,10 +162,8 @@ class AutoplayFrontend(pykka.ThreadingActor, core.CoreListener):
             # Generate a list of track URIs from URIs
             track_uris = [
                 track.uri
-                for sublist
-                in self.core.library.lookup(uris).get().values()
-                for track
-                in sublist]
+                for sublist in self.core.library.lookup(uris).get().values()
+                for track in sublist]
             # Clear tracklist and add tracks
             self.core.tracklist.clear()
             self.core.tracklist.set_consume(False)
@@ -241,7 +239,7 @@ class AutoplayFrontend(pykka.ThreadingActor, core.CoreListener):
             'tracklist': {},
             'mixer': {},
             'playback': {},
-            }
+        }
 
         # Tracks in tracklist
         tracklist = self.core.tracklist


### PR DESCRIPTION
Hello !

I made 2 small changes to the `restore_state` function

The first is to use library lookups instead of relying on playlist schemes to detect playlists from normal tracks, because it breaks with `spotify:` URIs (the scheme is registered in the playlist schemes, which means track URIs are processed as playlist URIs, preventing them to be added to the tracklist).

The second is to return before seeking, because if `seek` is called when the playback state is `stopped`, it will switch to `playing`, thus defeating the purpose of a `stopped` state.

I also took the liberty to create an Arch AUR package at https://aur.archlinux.org/packages/mopidy-autoplay/ .

Have a good day !